### PR TITLE
Show unverified-AI caption under vocab images; default include AI images

### DIFF
--- a/src/app/components/dictation-preload/dictation-preload.component.html
+++ b/src/app/components/dictation-preload/dictation-preload.component.html
@@ -57,6 +57,7 @@
           label="Preload.Images"
           iconClass="ico-tertiary"
           fillClass="fill-tertiary"
+          failedLabel="Preload.ImageFailed"
           [resetting]="resetting">
           <fa-icon [icon]="['fas', 'image']" size="sm"></fa-icon>
         </app-preload-row>

--- a/src/app/components/dictation-preload/dictation-preload.component.ts
+++ b/src/app/components/dictation-preload/dictation-preload.component.ts
@@ -63,6 +63,7 @@ export class DictationPreloadComponent implements OnDestroy {
     'Preload.Tip.PuzzleMode',
     'Preload.Tip.CreateDictation',
     'Preload.Tip.OfflineMode',
+    'Preload.Tip.Images',
   ];
 
   readonly lettersRow1 = [

--- a/src/app/components/vocab-image/vocab-image.component.spec.ts
+++ b/src/app/components/vocab-image/vocab-image.component.spec.ts
@@ -3,7 +3,7 @@ import {ComponentFixture, TestBed, waitForAsync} from '@angular/core/testing';
 import {SharedTestModule} from '../../../testing/shared-test.module';
 import {provideNoopAnimations} from '@angular/platform-browser/animations';
 import {VocabImageComponent} from './vocab-image';
-import {AILoadingImage, defaultImage} from '../../entity/dictation';
+import {defaultImage} from '../../entity/dictation';
 
 describe('VocabImageComponent', () => {
   let component: VocabImageComponent;
@@ -18,28 +18,65 @@ describe('VocabImageComponent', () => {
 
     fixture = TestBed.createComponent(VocabImageComponent);
     component = fixture.componentInstance;
-    fixture.detectChanges();
   }));
 
   it('default image if no images input', () => {
-    component.images = null;
-    component.ngOnChanges(null);
+    fixture.componentRef.setInput('images', null);
+    fixture.detectChanges();
     expect(component.imageBase64).toEqual(defaultImage[0]);
 
-    component.images = [];
-    component.ngOnChanges(null);
+    fixture.componentRef.setInput('images', []);
+    fixture.detectChanges();
     expect(component.imageBase64).toEqual(defaultImage[0]);
   });
 
-  it('AI loading image if no images input', () => {
-    component.AIImage = true;
-    component.images = null;
-    component.ngOnChanges(null);
-    expect(component.imageBase64).toEqual(AILoadingImage[0]);
-
-    component.images = [];
-    component.ngOnChanges(null);
+  it('uses default placeholder when images are missing', () => {
+    fixture.componentRef.setInput('images', []);
+    fixture.detectChanges();
     expect(component.imageBase64).toEqual(defaultImage[0]);
+    expect(component.showingPlaceholder).toBeTrue();
+  });
+
+  it('shows unverified note for real images when unverified is true', () => {
+    fixture.componentRef.setInput('images', ['https://example.com/a.jpg', 'https://example.com/b.jpg']);
+    fixture.componentRef.setInput('unverified', true);
+    fixture.detectChanges();
+
+    expect(component.showUnverifiedNote).toBeTrue();
+    expect(fixture.nativeElement.querySelector('.unverified-note-row')).toBeTruthy();
+  });
+
+  it('hides unverified note when unverified is false', () => {
+    fixture.componentRef.setInput('images', ['https://example.com/a.jpg']);
+    fixture.componentRef.setInput('unverified', false);
+    fixture.detectChanges();
+
+    expect(component.showUnverifiedNote).toBeFalse();
+    expect(fixture.nativeElement.querySelector('.unverified-note-row')).toBeNull();
+  });
+
+  it('hides unverified note for placeholder even when unverified is true', () => {
+    fixture.componentRef.setInput('images', []);
+    fixture.componentRef.setInput('unverified', true);
+    fixture.detectChanges();
+
+    expect(component.showUnverifiedNote).toBeFalse();
+    expect(fixture.nativeElement.querySelector('.unverified-note-row')).toBeNull();
+  });
+
+  it('keeps unverified note visible across carousel navigation', () => {
+    fixture.componentRef.setInput('images', ['https://example.com/a.jpg', 'https://example.com/b.jpg']);
+    fixture.componentRef.setInput('unverified', true);
+    fixture.detectChanges();
+    expect(component.showUnverifiedNote).toBeTrue();
+
+    component.nextImage();
+    component.onDone({} as any);
+    expect(component.showUnverifiedNote).toBeTrue();
+
+    component.previousImage();
+    component.onDone({} as any);
+    expect(component.showUnverifiedNote).toBeTrue();
   });
 
 });

--- a/src/app/components/vocab-image/vocab-image.html
+++ b/src/app/components/vocab-image/vocab-image.html
@@ -10,6 +10,12 @@
             fill="clear" class="button ion-float-right" size="small" (click)="nextImage()"><fa-icon [icon]="['fas', 'angle-right']"></fa-icon></ion-button>
           </ion-col>
         </ion-row>
-        <img [@move]="state" (@move.done)="onDone($event)" [src]="imageBase64 | safeHtml" class="image" />
+        <img [@move]="state" (@move.done)="onDone($event)" [src]="imageBase64 | safeHtml" class="image" alt="" />
+        @if (showUnverifiedNote) {
+          <div class="unverified-note-row">
+            <fa-icon [icon]="['fas', 'circle-info']"></fa-icon>
+            <ion-note color="medium">{{ 'VocabImage.UnverifiedAiNote' | translate }}</ion-note>
+          </div>
+        }
       </ion-card>
     }

--- a/src/app/components/vocab-image/vocab-image.scss
+++ b/src/app/components/vocab-image/vocab-image.scss
@@ -1,5 +1,6 @@
 ion-card {
-  height: 274px;
+  min-height: 274px;
+  height: auto;
 }
 
 .button {
@@ -17,4 +18,33 @@ ion-card {
 
 .grey-text {
   color: gray;
+}
+
+.unverified-note-row {
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  gap: 6px;
+  padding: 4px 12px 10px;
+}
+
+.unverified-note-row fa-icon {
+  flex: 0 0 auto;
+  color: var(--ion-color-medium);
+  font-size: 0.8rem;
+  line-height: 1.35;
+  height: calc(0.8rem * 1.35);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.unverified-note-row ion-note {
+  flex: 0 1 auto;
+  margin: 0;
+  padding: 0;
+  display: block;
+  font-size: 0.8rem;
+  line-height: 1.35;
+  text-align: start;
 }

--- a/src/app/components/vocab-image/vocab-image.ts
+++ b/src/app/components/vocab-image/vocab-image.ts
@@ -1,6 +1,6 @@
 import {Component, Input, OnChanges, SimpleChanges} from '@angular/core';
 import {animate, state, style, transition, trigger} from '@angular/animations';
-import {AILoadingImage, defaultImage} from '../../entity/dictation';
+import {defaultImage} from '../../entity/dictation';
 import {CollectionUtils} from '../../utils/collection-utils';
 import {DictationUtils} from '../../utils/dictation-utils';
 
@@ -23,11 +23,12 @@ import {DictationUtils} from '../../utils/dictation-utils';
     standalone: false
 })
 export class VocabImageComponent implements OnChanges {
-  @Input() images: string[]
-  @Input() AIImage: boolean = false;
+  @Input() images: string[];
+  @Input() unverified = false;
   index: number;
   state = 'center';
   imageBase64 = '';
+  showingPlaceholder = false;
 
   constructor() {
     this.index = 0;
@@ -35,15 +36,18 @@ export class VocabImageComponent implements OnChanges {
 
   ngOnChanges(_changes: SimpleChanges) {
     if (DictationUtils.notValidImages(this.images)) {
-      if (this.images == null) {
-        this.images = this.AIImage ? AILoadingImage : defaultImage;
-      } else {
-        this.images = defaultImage;
-      }
+      this.images = defaultImage;
+      this.showingPlaceholder = true;
+    } else {
+      this.showingPlaceholder = false;
     }
     this.images = CollectionUtils.shuffle(this.images);
     this.index = 0;
     this.imageBase64 = this.images[0];
+  }
+
+  get showUnverifiedNote(): boolean {
+    return this.unverified && !this.showingPlaceholder;
   }
 
   nextImage() {

--- a/src/app/components/vocab-selection/vocab-selection.component.spec.ts
+++ b/src/app/components/vocab-selection/vocab-selection.component.spec.ts
@@ -44,6 +44,7 @@ describe('VocabSelectionComponent', () => {
     expect(request.source).toEqual(Dictations.Source.Select);
     expect(request.dictationId).toEqual(-1);
     expect(request.showImage).toBeTruthy();
+    expect(request.includeAIImage).toBeTrue();
     expect(request.wordContainSpace).toBeTruthy();
   }));
 

--- a/src/app/components/vocab-selection/vocab-selection.component.ts
+++ b/src/app/components/vocab-selection/vocab-selection.component.ts
@@ -80,6 +80,7 @@ export class VocabSelectionComponent implements OnInit {
       dictationId: -1,
       title: this.title.value,
       showImage: true,
+      includeAIImage: true,
       vocabulary: Array.from(this.selectedVocabs.keys()),
       wordContainSpace : true,
       source : Dictations.Source.Select,

--- a/src/app/entity/voacb-practice.ts
+++ b/src/app/entity/voacb-practice.ts
@@ -16,6 +16,7 @@ export interface VocabPractice {
   activePronounceLink?: string;
   picsFullPathsInString?: string;
   suffledWord?: string;
+  imageIsVerify?: boolean;
 }
 
 export enum VocabDifficulty {

--- a/src/app/pages/dictation-practice/dictation-practice.page.html
+++ b/src/app/pages/dictation-practice/dictation-practice.page.html
@@ -82,7 +82,10 @@
               }
             </ion-col>
             <ion-col size="12" size-sm="12" size-md="6">
-              <vocab-image [images]="currentQuestion().picsFullPaths" [AIImage]="dictation.includeAIImage"></vocab-image>
+              <vocab-image
+                [images]="currentQuestion().picsFullPaths"
+                [unverified]="currentQuestion()?.imageIsVerify === false">
+              </vocab-image>
             </ion-col>
           </ion-row>
         </ion-grid>

--- a/src/app/pages/dictation-practice/dictation-practice.page.ts
+++ b/src/app/pages/dictation-practice/dictation-practice.page.ts
@@ -3,7 +3,7 @@ import {IonInput} from '@ionic/angular';
 import {of, Subject} from 'rxjs';
 import {mergeMap, tap} from 'rxjs/operators';
 import {VirtualKeyboardEvent} from '../../components/virtual-keyboard/virtual-keyboard';
-import {DictationPreloadComponent, PreloadCategoryName, PreloadResult} from '../../components/dictation-preload/dictation-preload.component';
+import {DictationPreloadComponent, PreloadResult} from '../../components/dictation-preload/dictation-preload.component';
 import {Dictation, PuzzleControls} from '../../entity/dictation';
 import {VocabPractice} from '../../entity/voacb-practice';
 import {VocabPracticeHistory} from '../../entity/vocab-practice-history';
@@ -124,7 +124,7 @@ export class DictationPracticePage {
   private fetchImages(vocabPractice: VocabPractice) {
     return this.dictation.showImage
       ? this.vocabPracticeService.getImages(vocabPractice, this.dictation.includeAIImage).pipe(
-          tap(vp => this.preload.recordImage(!!vp?.picsFullPaths))
+          tap(vp => this.preload.recordImage(vp.picsFullPaths != null))
         )
       : of(vocabPractice);
   }

--- a/src/app/pages/edit-dictation/edit-dictation.page.html
+++ b/src/app/pages/edit-dictation/edit-dictation.page.html
@@ -93,7 +93,7 @@
                           <div class="options-notes">
                             <div class="options-note-row">
                               <fa-icon [icon]="['fas', 'circle-info']"></fa-icon>
-                              <ion-note color="medium">{{'QuickDictation.OptionAvailabilityNote1'|translate}}</ion-note>
+                              <ion-note color="medium">{{'QuickDictation.VoiceAvailabilityNote'|translate}}</ion-note>
                             </div>
                           </div>
                         }
@@ -115,6 +115,14 @@
                                 </ion-item>
                               </ion-col>
                             </ion-row>
+                            @if (mode === pageMode.Start) {
+                              <div class="options-notes">
+                                <div class="options-note-row">
+                                  <fa-icon [icon]="['fas', 'circle-info']"></fa-icon>
+                                  <ion-note color="medium">{{'QuickDictation.ImageAvailabilityNote'|translate}}</ion-note>
+                                </div>
+                              </div>
+                            }
                             <ion-item>
                               <ion-toggle formControlName="wordContainSpace">
                                 <fa-icon [icon]="['fas', 'window-minimize']" /> {{'Words Contain Space'|translate}}

--- a/src/app/pages/edit-dictation/edit-dictation.page.scss
+++ b/src/app/pages/edit-dictation/edit-dictation.page.scss
@@ -73,20 +73,32 @@ fa-icon {
 .options-note-row {
   display: flex;
   align-items: flex-start;
-  gap: 4px;
+  gap: 6px;
 }
 
 .options-note-row + .options-note-row {
   margin-top: 6px;
 }
 
+// Icon height matches one note line so it aligns with the first text line.
 .options-note-row fa-icon {
+  flex: 0 0 auto;
   color: rgba(var(--ion-color-primary-rgb), 0.85);
-  padding-right: 4px;
-  padding-top: 1px;
+  // Override page-level `fa-icon { padding-right: 8px }` — gap handles spacing.
+  padding: 0;
+  font-size: 0.76rem;
+  line-height: 1.35;
+  height: calc(0.76rem * 1.35);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
 }
 
 .options-note-row ion-note {
+  flex: 1 1 auto;
+  min-width: 0;
+  margin: 0;
+  padding: 0;
   display: block;
   font-size: 0.76rem;
   line-height: 1.35;

--- a/src/app/pages/edit-dictation/edit-dictation.page.spec.ts
+++ b/src/app/pages/edit-dictation/edit-dictation.page.spec.ts
@@ -159,6 +159,16 @@ describe('EditDictationPage', () => {
         fixture.detectChanges(false);
         expect(fixture.nativeElement.querySelector('.include-ai-image-toggle')).toBeNull();
       }));
+
+      it('defaults show image and include AI image to true for new create dictation', fakeAsync(() => {
+        storageSpy.get.and.returnValue(Promise.resolve(null));
+        navigationServiceSpy.getParam.and.returnValue(null);
+
+        componentViewWillEnter();
+
+        expect(component.showImage.value).toBeTrue();
+        expect(component.includeAIImage.value).toBeTrue();
+      }));
     });
   });
 
@@ -292,6 +302,16 @@ describe('EditDictationPage', () => {
 
           component.showImage.setValue(true);
           fixture.detectChanges(false);
+          expect(component.includeAIImage.enabled).toBeTrue();
+        }));
+
+        it('defaults show image and include AI image to true when no saved options', fakeAsync(() => {
+          storageSpy.get.and.returnValue(Promise.resolve(null));
+
+          componentViewWillEnter();
+
+          expect(component.showImage.value).toBeTrue();
+          expect(component.includeAIImage.value).toBeTrue();
           expect(component.includeAIImage.enabled).toBeTrue();
         }));
 

--- a/src/app/pages/edit-dictation/edit-dictation.page.ts
+++ b/src/app/pages/edit-dictation/edit-dictation.page.ts
@@ -51,7 +51,7 @@ export class EditDictationPage implements OnInit, CanComponentDeactivate {
     type: DictationType.Word,
     sentenceLength: 'Normal',
     showImage: true,
-    includeAIImage: false,
+    includeAIImage: true,
     wordContainSpace: false,
     wordPracticeType: VocabPracticeType.Spell,
   };
@@ -292,8 +292,8 @@ export class EditDictationPage implements OnInit, CanComponentDeactivate {
       voiceMode: this.resolveVoiceMode(savedVoiceMode),
       type: this.resolveType(savedType),
       sentenceLength: this.resolveSentenceLength(savedSentenceLength),
-      showImage: this.toBoolean(savedShowImage),
-      includeAIImage: this.toBoolean(savedIncludeAiImage),
+      showImage: this.toBoolean(savedShowImage, EditDictationPage.defaultSavedOptions.showImage),
+      includeAIImage: this.toBoolean(savedIncludeAiImage, EditDictationPage.defaultSavedOptions.includeAIImage),
       wordContainSpace: this.toBoolean(savedWordContainSpace),
       wordPracticeType: this.resolveWordPracticeType(savedWordPracticeType),
     };
@@ -311,7 +311,10 @@ export class EditDictationPage implements OnInit, CanComponentDeactivate {
     return practiceType === VocabPracticeType.Puzzle ? VocabPracticeType.Puzzle : VocabPracticeType.Spell;
   }
 
-  private toBoolean(value: unknown): boolean {
+  private toBoolean(value: unknown, defaultValue = false): boolean {
+    if (value === undefined || value === null) {
+      return defaultValue;
+    }
     return value === true || value === 'true' || value === 1 || value === '1';
   }
 

--- a/src/app/services/practice/vocab-practice.service.spec.ts
+++ b/src/app/services/practice/vocab-practice.service.spec.ts
@@ -4,13 +4,14 @@ import {VocabPracticeHistory} from '../../entity/vocab-practice-history';
 import {vocab_apple, vocab_banana} from '../../../testing/test-data';
 import {HttpClient} from '@angular/common/http';
 import {Dictations, PuzzleControls} from '../../entity/dictation';
+import {of, throwError} from 'rxjs';
 
 describe('VocabPracticeService', () => {
   let service: VocabPracticeService;
   let httpClientSpy;
 
   beforeEach(() => {
-    httpClientSpy = jasmine.createSpyObj('HttpClient', ['post']);
+    httpClientSpy = jasmine.createSpyObj('HttpClient', ['post', 'get']);
 
     TestBed.configureTestingModule({
     imports: [],
@@ -68,6 +69,7 @@ describe('VocabPracticeService', () => {
     expect(result.id).toEqual(-1);
     expect(result.source).toEqual(Dictations.Source.Generate);
     expect(result.showImage).toBeTruthy();
+    expect(result.includeAIImage).toBeTrue();
     expect(result.vocabs.length).toEqual(1);
     expect(result.vocabs[0].word).toEqual('test');
     expect(result.source).toEqual(Dictations.Source.Generate);
@@ -86,6 +88,60 @@ describe('VocabPracticeService', () => {
 
   it('imageUrl can create correct url', () => {
     expect(service.imageUrl('i am ok')).toContain('images%2Fi-%2Fi-am-ok.json?alt=media');
+  });
+
+  it('getImages accepts unverified AI images when includeAIImage is true', (done) => {
+    const practice = { word: 'unicorn', picsFullPaths: null } as any;
+    httpClientSpy.get.and.returnValue(of({ images: ['img1'], isVerify: false }));
+
+    service.getImages(practice, true).subscribe(result => {
+      expect(result.picsFullPaths).toEqual(['img1']);
+      expect(result.imageIsVerify).toBeFalse();
+      done();
+    });
+  });
+
+  it('getImages hides unverified AI images with empty array when includeAIImage is false', (done) => {
+    const practice = { word: 'unicorn', picsFullPaths: null } as any;
+    httpClientSpy.get.and.returnValue(of({ images: ['img1'], isVerify: false }));
+
+    service.getImages(practice, false).subscribe(result => {
+      expect(result.picsFullPaths).toEqual([]);
+      expect(result.imageIsVerify).toBeFalse();
+      done();
+    });
+  });
+
+  it('getImages accepts verified images when includeAIImage is false', (done) => {
+    const practice = { word: 'apple', picsFullPaths: null } as any;
+    httpClientSpy.get.and.returnValue(of({ images: ['img1'], isVerify: true }));
+
+    service.getImages(practice, false).subscribe(result => {
+      expect(result.picsFullPaths).toEqual(['img1']);
+      expect(result.imageIsVerify).toBeTrue();
+      done();
+    });
+  });
+
+  it('getImages leaves imageIsVerify undefined when picsFullPaths already valid', (done) => {
+    const practice = { word: 'apple', picsFullPaths: ['existing.jpg'] } as any;
+
+    service.getImages(practice, true).subscribe(result => {
+      expect(result.picsFullPaths).toEqual(['existing.jpg']);
+      expect(result.imageIsVerify).toBeUndefined();
+      expect(httpClientSpy.get).not.toHaveBeenCalled();
+      done();
+    });
+  });
+
+  it('getImages sets picsFullPaths to null on error', (done) => {
+    const practice = { word: 'apple', picsFullPaths: null } as any;
+    httpClientSpy.get.and.returnValue(throwError(() => new Error('network')));
+
+    service.getImages(practice, true).subscribe(result => {
+      expect(result.picsFullPaths).toBeNull();
+      done();
+    });
   });
 
   describe('test receiveAnswer', () => {

--- a/src/app/services/practice/vocab-practice.service.ts
+++ b/src/app/services/practice/vocab-practice.service.ts
@@ -43,20 +43,22 @@ export class VocabPracticeService extends Service {
     console.log(`picsFullPaths from server: ${vocabPractice.picsFullPaths}`);
     if (!DictationUtils.notValidImages(vocabPractice.picsFullPaths)) {
       return of(vocabPractice);
-    } else {
-      return this.http.get<ImagesObject>(this.imageUrl(vocabPractice.word))
-        .pipe(
-          map(imagesObject => {
-            console.log(`imagesObject verified=${imagesObject.isVerify}`);
-            vocabPractice.picsFullPaths = (includeAIImage || imagesObject.isVerify) ? imagesObject.images : null;
-            return vocabPractice;
-          }),
-          catchError(error => {
-            vocabPractice.picsFullPaths = null;
-            return of(vocabPractice);
-          })
-        );
     }
+
+    return this.http.get<ImagesObject>(this.imageUrl(vocabPractice.word))
+      .pipe(
+        map(imagesObject => {
+          console.log(`imagesObject verified=${imagesObject.isVerify}`);
+          const acceptImages = includeAIImage || imagesObject.isVerify === true;
+          vocabPractice.imageIsVerify = imagesObject.isVerify;
+          vocabPractice.picsFullPaths = acceptImages ? imagesObject.images : [];
+          return vocabPractice;
+        }),
+        catchError(() => {
+          vocabPractice.picsFullPaths = null;
+          return of(vocabPractice);
+        })
+      );
   }
 
   imageUrl(phrase: string): string {
@@ -85,6 +87,7 @@ export class VocabPracticeService extends Service {
     return <Dictation>{
       id: -1,
       showImage: true,
+      includeAIImage: true,
       vocabs: words.map(s => <Vocab>{word: s}),
       source: Dictations.Source.Generate,
     };

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -78,12 +78,14 @@
   "Local Voice": "Local computer",
   "VoiceMode.OnlineDescription": "Natural AI or recorded human voice from internet",
   "VoiceMode.LocalDescription": "Generated voice without internet usage",
-  "QuickDictation.OptionAvailabilityNote1": "In Quick Dictation, AI image and Online AI / Human voice may not always be available. Please log in and create dictation to ensure their availability.",
+  "QuickDictation.ImageAvailabilityNote": "New images are created only when a logged-in user saves a dictation. Quick Dictation only shows images that are already available.",
+  "QuickDictation.VoiceAvailabilityNote": "Some voices take a little longer to become available. Please wait if they aren't ready yet.",
   "Preload.Questions": "Questions",
   "Preload.Voices": "Voices",
   "Preload.Images": "Images",
   "Preload.Ready": "Ready",
   "Preload.VoiceFailed": "Some audio couldn't be loaded",
+  "Preload.ImageFailed": "Some images couldn't be loaded",
   "Preload.ContinueLocalVoice": "Continue with local voice",
   "Preload.Status.Preparing": "Preparing dictation...",
   "Preload.Status.AllReady": "Ready to practice!",
@@ -93,5 +95,7 @@
   "Preload.Tip.SpeakPunctuation": "Enable 'Speak Punctuation' to hear commas and periods.",
   "Preload.Tip.PuzzleMode": "Try puzzle mode to reorder letters instead of typing.",
   "Preload.Tip.CreateDictation": "Create your own dictation from any word list.",
-  "Preload.Tip.OfflineMode": "Local voice works offline — great for practice on the go."
+  "Preload.Tip.OfflineMode": "Local voice works offline — great for practice on the go.",
+  "Preload.Tip.Images": "AI images are generated only when a dictation is saved.",
+  "VocabImage.UnverifiedAiNote": "AI image — may not match this word"
 }

--- a/src/assets/i18n/zh-Hans.json
+++ b/src/assets/i18n/zh-Hans.json
@@ -247,12 +247,14 @@
   "Local Voice": "本机电脑",
   "VoiceMode.OnlineDescription": "网络的 AI 语音或真人录音",
   "VoiceMode.LocalDescription": "本机生成语音,不使用网络",
-  "QuickDictation.OptionAvailabilityNote1": "在快速听写中，不一定能提供 AI 图像与在线 AI／真人语音。请先登录并创建听写，以确保这些功能可用。",
+  "QuickDictation.ImageAvailabilityNote": "只有已登录用户保存听写时才会生成新图像。快速听写只会显示已经可用的图像。",
+  "QuickDictation.VoiceAvailabilityNote": "部分语音需要多等一会儿才会可用。如果暂时还没有，请再等一下。",
   "Preload.Questions": "题目",
   "Preload.Voices": "语音",
   "Preload.Images": "图像",
   "Preload.Ready": "就绪",
   "Preload.VoiceFailed": "部分语音无法加载",
+  "Preload.ImageFailed": "部分图像无法加载",
   "Preload.ContinueLocalVoice": "使用本机语音继续",
   "Preload.Status.Preparing": "准备听写练习...",
   "Preload.Status.AllReady": "准备就绪！",
@@ -262,5 +264,7 @@
   "Preload.Tip.SpeakPunctuation": "开启「读出标点」可听到逗号和句号。",
   "Preload.Tip.PuzzleMode": "试试拼图模式，选字母代替打字。",
   "Preload.Tip.CreateDictation": "用任何单词表建立自己的听写练习。",
-  "Preload.Tip.OfflineMode": "本机语音离线也能用，随时随地练习。"
+  "Preload.Tip.OfflineMode": "本机语音离线也能用，随时随地练习。",
+  "Preload.Tip.Images": "AI 图像仅在保存听写后生成。",
+  "VocabImage.UnverifiedAiNote": "AI 图像，可能与词义不符"
 }

--- a/src/assets/i18n/zh-Hant.json
+++ b/src/assets/i18n/zh-Hant.json
@@ -247,12 +247,14 @@
   "Local Voice": "本機電腦",
   "VoiceMode.OnlineDescription": "來自網絡的自然 AI 或真人錄音",
   "VoiceMode.LocalDescription": "本機生成語音,不使用網絡",
-  "QuickDictation.OptionAvailabilityNote1": "在快速聽寫中，不一定能提供 AI 圖像與網上 AI／真人語音。請先登入並建立聽寫，以確保這些功能可用。",
+  "QuickDictation.ImageAvailabilityNote": "只有已登入用戶儲存聽寫時才會生成新圖像。快速聽寫只會顯示已經可用的圖像。",
+  "QuickDictation.VoiceAvailabilityNote": "部分語音需要多等一會兒才會可用。如果暫時還沒有，請再等一下。",
   "Preload.Questions": "題目",
   "Preload.Voices": "語音",
   "Preload.Images": "圖像",
   "Preload.Ready": "就緒",
   "Preload.VoiceFailed": "部分語音無法載入",
+  "Preload.ImageFailed": "部分圖像無法載入",
   "Preload.ContinueLocalVoice": "使用本機語音繼續",
   "Preload.Status.Preparing": "準備聽寫練習...",
   "Preload.Status.AllReady": "準備就緒！",
@@ -262,5 +264,7 @@
   "Preload.Tip.SpeakPunctuation": "開啟「讀出標點」可聽到逗號和句號。",
   "Preload.Tip.PuzzleMode": "試試拼圖模式，選字母代替打字。",
   "Preload.Tip.CreateDictation": "用任何單詞表建立自己的聽寫練習。",
-  "Preload.Tip.OfflineMode": "本機語音離線也能用，隨時隨地練習。"
+  "Preload.Tip.OfflineMode": "本機語音離線也能用，隨時隨地練習。",
+  "Preload.Tip.Images": "AI 圖像僅在儲存聽寫後產生。",
+  "VocabImage.UnverifiedAiNote": "AI 圖像，可能與詞義不符"
 }


### PR DESCRIPTION
## Summary
- Under-image centered trust note when `imageIsVerify === false` and real images are shown (`VocabImage.UnverifiedAiNote` in en / zh-Hans / zh-Hant)
- Map Firebase `ImagesObject.isVerify` → practice `imageIsVerify`; treat rejected unverified fetches as `[]` (opt-out) vs `null` (error) for preload
- Default `includeAIImage` on for quick/create/generate/select flows; split Quick image vs voice availability notes and preload image tip/failure copy

## Test plan
- [ ] Practice with Include AI Image on + unverified word: caption under image, centered with icon
- [ ] Verified image / placeholder / Include AI off: no caption
- [ ] Carousel next/prev keeps caption
- [ ] Quick Dictation: image + voice availability notes read correctly
- [ ] Preload image tip / failure copy when images missing
- [ ] Unit: vocab-image, vocab-practice.service, edit-dictation, vocab-selection, dictation-preload (64 focused tests passed locally)


Made with [Cursor](https://cursor.com)