### PR TITLE
Add owner-only Edit on finish practice pages

### DIFF
--- a/.cursor/agents/esl-ionic-reviewer.md
+++ b/.cursor/agents/esl-ionic-reviewer.md
@@ -5,7 +5,7 @@ description: >-
   finishes implementation (or when the user asks to review a client PR/diff).
   Reviews correctness, UX fidelity to briefs, Ionic/platform pitfalls, and
   tests — does not write app code. Readonly.
-model: claude-opus-4-8[effort=high]
+model: cursor-grok-4.5-high
 readonly: true
 ---
 

--- a/.cursor/agents/esl-ionic-senior-dev.md
+++ b/.cursor/agents/esl-ionic-senior-dev.md
@@ -6,7 +6,7 @@ description: >-
   there is no agreed plan yet. Produces design analysis and an implementation
   brief only — does not write app code. Skip when an accepted plan already
   covers this repo. For visual/UX direction, esl-uiux runs first.
-model: claude-opus-4-8[effort=high]
+model: cursor-grok-4.5-high
 readonly: true
 ---
 

--- a/.cursor/agents/esl-ui-writer.md
+++ b/.cursor/agents/esl-ui-writer.md
@@ -7,7 +7,7 @@ description: >-
   empty/error/success messages for esl-ionic. Produces wording only — does not
   write app code. Prefer this over inventing labels inside esl-uiux or
   programmers.
-model: claude-opus-4-8[effort=high]
+model: cursor-grok-4.5-high
 readonly: true
 ---
 

--- a/.cursor/agents/esl-uiux.md
+++ b/.cursor/agents/esl-uiux.md
@@ -6,7 +6,7 @@ description: >-
   BEFORE designing screens, changing layout/visuals, rewriting components for
   UX, adding flows, or approving UI implementation plans. Produces design/UX
   specs only — does not write app code. Do not skip this agent for UI work.
-model: claude-opus-4-8[effort=high]
+model: cursor-grok-4.5-high
 readonly: true
 ---
 

--- a/src/app/pages/article-dictation-complete/article-dictation-complete.page.html
+++ b/src/app/pages/article-dictation-complete/article-dictation-complete.page.html
@@ -33,6 +33,11 @@
               <fa-icon [icon]="['fas', 'save']"></fa-icon>&nbsp;{{'Save'|translate}}
             </ion-button>
           }
+          @if (showEditButton()) {
+            <ion-button color="secondary" (click)="navigationService.editDictation(dictation)">
+              <fa-icon [icon]="['fas', 'edit']"></fa-icon>&nbsp;{{'Edit'|translate}}
+            </ion-button>
+          }
         </div>
 
         <div dictationOptionActions class="complete-retry-actions">

--- a/src/app/pages/article-dictation-complete/article-dictation-complete.page.spec.ts
+++ b/src/app/pages/article-dictation-complete/article-dictation-complete.page.spec.ts
@@ -3,26 +3,32 @@ import {ComponentFixture, fakeAsync, TestBed, waitForAsync} from '@angular/core/
 
 import {ArticleDictationCompletePage} from './article-dictation-complete.page';
 import {SharedTestModule} from '../../../testing/shared-test.module';
-import {dictation1, dictation1Histories} from '../../../testing/test-data';
-import {FFSAuthServiceSpy, ManageVocabHistoryServiceSpy, StorageSpy} from '../../../testing/mocks-ionic';
+import {dictation1, dictation1Histories, member1} from '../../../testing/test-data';
+import {FFSAuthServiceSpy, ManageVocabHistoryServiceSpy, NavigationServiceSpy, StorageSpy} from '../../../testing/mocks-ionic';
 import {DictationService} from '../../services/dictation/dictation.service';
 import {ActivatedRoute, convertToParamMap} from '@angular/router';
 import {ManageVocabHistoryService} from '../../services/member/manage-vocab-history.service';
 import {StorageService} from '../../services/storage.service';
 import {FFSAuthService} from '../../services/auth.service';
+import {NavigationService} from '../../services/navigation.service';
+import {Dictation, Dictations} from '../../entity/dictation';
 
 describe('ArticleDictationCompletePage', () => {
   let component: ArticleDictationCompletePage;
   let fixture: ComponentFixture<ArticleDictationCompletePage>;
   let dictationServiceSpy;
   let authServiceSpy;
+  let navigationServiceSpy;
 
   beforeEach(waitForAsync(() => {
     dictationServiceSpy = jasmine.createSpyObj('DictationService', ['createSentenceDictationHistory', 'isInstantDictation']);
     dictationServiceSpy.isInstantDictation.and.returnValue(false);
-    
+
     authServiceSpy = FFSAuthServiceSpy();
     authServiceSpy.isAuthenticated.and.returnValue(true);
+
+    navigationServiceSpy = NavigationServiceSpy();
+    navigationServiceSpy.editDictation = jasmine.createSpy('editDictation');
 
     const params = {
       'dictation': dictation1,
@@ -42,6 +48,7 @@ describe('ArticleDictationCompletePage', () => {
         { provide: StorageService, useValue: storageSpy },
         { provide: ManageVocabHistoryService, useValue: ManageVocabHistoryServiceSpy},
         { provide: FFSAuthService, useValue: authServiceSpy },
+        { provide: NavigationService, useValue: navigationServiceSpy },
         { provide: ActivatedRoute, useValue: {
             snapshot: {
               queryParamMap: convertToParamMap({
@@ -75,4 +82,55 @@ describe('ArticleDictationCompletePage', () => {
     component.init();
     expect(dictationServiceSpy.createSentenceDictationHistory.calls.count()).toEqual(0);
   }));
+
+  describe('showEditButton', () => {
+    function ownerFillInDictation(): Dictation {
+      const dictation = { ...dictation1, id: 1, source: Dictations.Source.FillIn, creator: member1 };
+      return dictation;
+    }
+
+    beforeEach(() => {
+      authServiceSpy.isAuthenticated.and.returnValue(true);
+      authServiceSpy.userProfile = { email: member1.emailAddress };
+    });
+
+    it('returns true for owner FillIn saved dictation', () => {
+      component.dictation = ownerFillInDictation();
+      expect(component.showEditButton()).toBeTrue();
+    });
+
+    it('returns false for non-owner', () => {
+      component.dictation = ownerFillInDictation();
+      authServiceSpy.userProfile = { email: 'other@gmail.com' };
+      expect(component.showEditButton()).toBeFalse();
+    });
+
+    it('returns false when unauthenticated', () => {
+      component.dictation = ownerFillInDictation();
+      authServiceSpy.isAuthenticated.and.returnValue(false);
+      expect(component.showEditButton()).toBeFalse();
+    });
+
+    it('returns false for non-FillIn source', () => {
+      component.dictation = { ...ownerFillInDictation(), source: Dictations.Source.Generate };
+      expect(component.showEditButton()).toBeFalse();
+    });
+
+    it('returns false when id <= 0', () => {
+      component.dictation = { ...ownerFillInDictation(), id: 0 };
+      expect(component.showEditButton()).toBeFalse();
+    });
+
+    it('returns false when creator is undefined', () => {
+      component.dictation = { ...ownerFillInDictation(), creator: undefined };
+      expect(component.showEditButton()).toBeFalse();
+    });
+
+    it('Edit tap calls navigationService.editDictation once', () => {
+      const dictation = ownerFillInDictation();
+      component.dictation = dictation;
+      component.navigationService.editDictation(dictation);
+      expect(navigationServiceSpy.editDictation).toHaveBeenCalledOnceWith(dictation);
+    });
+  });
 });

--- a/src/app/pages/article-dictation-complete/article-dictation-complete.page.ts
+++ b/src/app/pages/article-dictation-complete/article-dictation-complete.page.ts
@@ -1,5 +1,5 @@
 import {Component, OnInit, ViewChild} from '@angular/core';
-import {Dictation} from "../../entity/dictation";
+import {Dictation, Dictations} from "../../entity/dictation";
 import {SentenceHistory} from "../../entity/sentence-history";
 import {DictationService} from "../../services/dictation/dictation.service";
 import {NavigationService} from "../../services/navigation.service";
@@ -105,6 +105,14 @@ export class ArticleDictationCompletePage implements OnInit {
     console.warn(`Cannot get dictation: ${JSON.stringify(error)}`);
     if (this.loader) this.loader.dismiss();
     this.ionicComponentService.showToastMessage(this.translateService.instant('Dictation not found'), 'top');
+  }
+
+  showEditButton(): boolean {
+    return !!this.dictation
+      && this.authService.isAuthenticated()
+      && this.dictation.source === Dictations.Source.FillIn
+      && this.dictation.id > 0
+      && this.dictation.creator?.emailAddress === this.authService.userProfile?.email;
   }
 
 }

--- a/src/app/pages/practice-complete/practice-complete.page.html
+++ b/src/app/pages/practice-complete/practice-complete.page.html
@@ -35,6 +35,11 @@
               <fa-icon [icon]="['fas', 'save']"></fa-icon>&nbsp;{{'Save'|translate}}
             </ion-button>
           }
+          @if (showEditButton()) {
+            <ion-button color="secondary" (click)="navigationService.editDictation(dictation)">
+              <fa-icon [icon]="['fas', 'edit']"></fa-icon>&nbsp;{{'Edit'|translate}}
+            </ion-button>
+          }
           @if (showOpenMyVocabulary()) {
             <ion-button class="open-my-vocab-button" color="secondary" (click)="navigationService.openMemberHome('vocabulary')">
               <fa-icon icon="folder-open"></fa-icon>&nbsp;{{'My Vocabulary'|translate}}

--- a/src/app/pages/practice-complete/practice-complete.page.spec.ts
+++ b/src/app/pages/practice-complete/practice-complete.page.spec.ts
@@ -13,6 +13,7 @@ import {
 } from '../../../testing/mocks-ionic';
 import {SharedTestModule} from '../../../testing/shared-test.module';
 import {TestData} from '../../../testing/test-data';
+import {member1} from '../../../testing/test-data';
 import {Dictation} from '../../entity/dictation';
 import {VocabPracticeType} from '../../enum/vocab-practice-type.enum';
 import {FFSAuthService} from '../../services/auth.service';
@@ -37,6 +38,7 @@ describe('PracticeCompletePage', () => {
     storageSpy = StorageSpy();
     authServiceSpy = FFSAuthServiceSpy();
     navigationServiceSpy = NavigationServiceSpy();
+    navigationServiceSpy.editDictation = jasmine.createSpy('editDictation');
     manageVocabHistoryServiceSpy = ManageVocabHistoryServiceSpy();
     ionicComponentServiceSpy = IonicComponentServiceSpy();
 
@@ -226,6 +228,66 @@ describe('PracticeCompletePage', () => {
       expect(manageVocabHistoryServiceSpy.classifyVocabulary.calls.count()).toEqual(1);
       expect(dictationServiceSpy.createVocabDictationHistory.calls.count()).toEqual(0);
     }));
+  });
+
+  describe('showEditButton', () => {
+    function ownerFillInDictation(): Dictation {
+      const dictation = TestData.fillInDictation();
+      dictation.id = 999;
+      dictation.creator = member1;
+      return dictation;
+    }
+
+    beforeEach(() => {
+      authServiceSpy.isAuthenticated.and.returnValue(true);
+      authServiceSpy.userProfile = { email: member1.emailAddress };
+    });
+
+    it('returns true for owner FillIn saved dictation', () => {
+      component.dictation = ownerFillInDictation();
+      expect(component.showEditButton()).toBeTrue();
+    });
+
+    it('returns false for non-owner', () => {
+      component.dictation = ownerFillInDictation();
+      authServiceSpy.userProfile = { email: 'other@gmail.com' };
+      expect(component.showEditButton()).toBeFalse();
+    });
+
+    it('returns false when unauthenticated', () => {
+      component.dictation = ownerFillInDictation();
+      authServiceSpy.isAuthenticated.and.returnValue(false);
+      expect(component.showEditButton()).toBeFalse();
+    });
+
+    it('returns false for non-FillIn source', () => {
+      const dictation = TestData.generateDictation();
+      dictation.id = 999;
+      dictation.creator = member1;
+      component.dictation = dictation;
+      expect(component.showEditButton()).toBeFalse();
+    });
+
+    it('returns false when id <= 0', () => {
+      const dictation = ownerFillInDictation();
+      dictation.id = 0;
+      component.dictation = dictation;
+      expect(component.showEditButton()).toBeFalse();
+    });
+
+    it('returns false when creator is undefined', () => {
+      const dictation = ownerFillInDictation();
+      dictation.creator = undefined;
+      component.dictation = dictation;
+      expect(component.showEditButton()).toBeFalse();
+    });
+
+    it('Edit tap calls navigationService.editDictation once', () => {
+      const dictation = ownerFillInDictation();
+      component.dictation = dictation;
+      component.navigationService.editDictation(dictation);
+      expect(navigationServiceSpy.editDictation).toHaveBeenCalledOnceWith(dictation);
+    });
   });
 
 });

--- a/src/app/pages/practice-complete/practice-complete.page.ts
+++ b/src/app/pages/practice-complete/practice-complete.page.ts
@@ -103,6 +103,14 @@ export class PracticeCompletePage implements OnInit {
     return this.dictation && !this.dictationHelper.isInstantDictation(this.dictation) && !this.historyStored && this.dictation.source === Dictations.Source.FillIn;
   }
 
+  showEditButton(): boolean {
+    return !!this.dictation
+      && this.authService.isAuthenticated()
+      && this.dictation.source === Dictations.Source.FillIn
+      && this.dictation.id > 0
+      && this.dictation.creator?.emailAddress === this.authService.userProfile?.email;
+  }
+
   recommendBtnText(): string {
     return this.translate.instant(this.recommended ? 'Recommended' : 'Recommend');
   }


### PR DESCRIPTION
## Summary
- Show an owner-only **Edit** action on practice-complete and article-dictation-complete so authors can jump back to edit their dictation after finishing.
- Cover the new UI/behavior with page specs.
- Pin Ionic design/review Cursor agents (`senior-dev`, `reviewer`, `uiux`, `ui-writer`) to `cursor-grok-4.5-high` instead of Claude Opus (first-party models only).

## Test plan
- [ ] As dictation owner, finish word practice → Edit appears on practice-complete → opens edit flow
- [ ] As dictation owner, finish article/sentence practice → Edit appears on article-dictation-complete → opens edit flow
- [ ] As non-owner (or guest viewing someone else’s list), Edit is hidden on both finish pages
- [ ] Existing finish-page actions (retry, recommend/save, score) still work
- [ ] Unit/spec suites for both complete pages pass


Made with [Cursor](https://cursor.com)