### PR TITLE
Fix search dictation history not loading on Ionic 8

### DIFF
--- a/src/app/pages/search-dictation/search-dictation.page.spec.ts
+++ b/src/app/pages/search-dictation/search-dictation.page.spec.ts
@@ -73,8 +73,8 @@ describe('SearchDictationPage', () => {
   }));
 
 
-  it('history is loaded from storage when init, and updated when search', fakeAsync(() => {
-    component.ionViewDidLoad();
+  it('history is loaded from storage when view enters, and updated when search', fakeAsync(() => {
+    component.ionViewDidEnter();
     tick();
     expect(component.history[0]).toBe('old search history');
 

--- a/src/app/pages/search-dictation/search-dictation.page.ts
+++ b/src/app/pages/search-dictation/search-dictation.page.ts
@@ -61,7 +61,7 @@ export class SearchDictationPage implements OnInit {
     this.inputForm.get('suitableStudent').setValue('Any');
   }
 
-  ionViewDidLoad() {
+  ionViewDidEnter() {
     this.storage.get(this.SEARCH_HISTORY_KEY).then(h => {
       this.history = h ? h : [];
     });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Rename `ionViewDidLoad` to `ionViewDidEnter` on the search dictation page so search history is loaded from `StorageService` when the page enters.
- Update the unit test to call `ionViewDidEnter` and describe the Ionic 8 lifecycle behavior.

## Context
`ionViewDidLoad` is an Ionic 3 hook and does not run on Ionic 8, so search history autocomplete never loaded even though history was still saved on search.

## Test plan
- [x] Run `npx ng test --browsers=ChromeHeadlessCI --watch=false --include='**/search-dictation.page.spec.ts'` — 7/7 SUCCESS
- [ ] Manually verify search history autocomplete populates after prior searches on `/search-dictation`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fa0ee-dfa9-7e73-8d15-a9bea3257a87"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fa0ee-dfa9-7e73-8d15-a9bea3257a87"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

