### PR TITLE
Reduce Actions artifact retention to 7 days

### DIFF
--- a/.github/workflows/build-test-deploy_uat.yml
+++ b/.github/workflows/build-test-deploy_uat.yml
@@ -29,6 +29,7 @@ jobs:
         with:
          name: www
          path: www
+         retention-days: 7
       - name: Publish Test Results
         uses: EnricoMi/publish-unit-test-result-action@v2
         if: github.ref == 'refs/heads/master'
@@ -55,6 +56,7 @@ jobs:
           path: |
             playwright-report
             test-results
+          retention-days: 7
 
   deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/manual-deploy.yml
+++ b/.github/workflows/manual-deploy.yml
@@ -21,6 +21,7 @@ jobs:
         with:
          name: www
          path: www
+         retention-days: 7
   deploy:
     runs-on: ubuntu-latest
     needs: [ build ]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
GitHub Actions storage is near the free 0.5 GB limit. `www` and Playwright artifacts were keeping the default **90-day** retention.

## Change
Set `retention-days: 7` on artifact uploads in:
- `.github/workflows/build-test-deploy_uat.yml` (`www`, `playwright-report`)
- `.github/workflows/manual-deploy.yml` (`www`)

Existing artifacts are unchanged; delete them from [Actions → Artifacts](https://github.com/thcathy/esl-ionic/actions/artifacts) if you need space immediately.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fa5f2-9e73-736d-8460-1c2daca0c3da"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fa5f2-9e73-736d-8460-1c2daca0c3da"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

